### PR TITLE
Ctrl-Shift-hover to navigate from browser to template source

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,24 +6,30 @@ version = "1.0.1"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Match = "7eb4fadd-790c-5f42-8a69-bfa0b872bfbf"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [weakdeps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [extensions]
+HypertextTemplatesHTTPReviseExt = ["HTTP", "Revise"]
 HypertextTemplatesReviseExt = "Revise"
 
 [compat]
 AbstractTrees = "0.4"
 EzXML = "1"
+InteractiveUtils = "1.6"
 Logging = "1.6"
 LoggingExtras = "1"
 MacroTools = "0.5"
 Match = "2"
 PackageExtensionCompat = "1"
+Random = "1.6"
 julia = "1.6"

--- a/ext/HypertextTemplatesHTTPReviseExt.jl
+++ b/ext/HypertextTemplatesHTTPReviseExt.jl
@@ -1,0 +1,74 @@
+module HypertextTemplatesHTTPReviseExt
+
+import HTTP
+import HypertextTemplates
+import InteractiveUtils
+import Random
+import Revise
+
+function HypertextTemplates._template_file_lookup(
+    ::HypertextTemplates.TemplateFileLookupType,
+    handler,
+)
+    # Generate a random target to avoid potential collisions if a user has a
+    # page that uses the same target, as unlikely as that may be.
+    target = "/template-file-lookup-$(Random.randstring())"
+    function (request::HTTP.Request)
+        if request.method == "POST" && request.target == target
+            filename = String(request.body)
+            if isfile(filename)
+                @debug "Opening $filename for editing."
+                InteractiveUtils.edit(filename)
+                return HTTP.Response(200, "Opened file in default editor.")
+            else
+                error("filename does not exist: $filename")
+            end
+        else
+            return _insert_template_file_lookup_listener(handler(request), target)
+        end
+    end
+end
+
+# Injects a script into the response that listens for clicks on elements with
+# the `data-filename` attribute and sends a POST request to the given address
+# with the filename as the body. This is used to open the template file in the
+# default editor when the user clicks on the rendered template.
+function _insert_template_file_lookup_listener(
+    response::HTTP.Response,
+    address::AbstractString,
+)
+    if !isnothing(findfirst((==)("Content-Type" => "text/html"), response.headers))
+        tags = "</head>"
+        script = """
+        <script>
+        // Track the mouse position so that we can lookup the element under the
+        // cursor when the user presses Ctrl+Shift.
+        window.addEventListener("mousemove", async function (event) {
+            window._lastMousePosition = { x: event.clientX, y: event.clientY };
+        });
+        // Listen for Ctrl+Shift clicks on elements with the `data-filename`
+        // attribute and send a POST request to the given address with the
+        // filename as the body.
+        window.addEventListener("keydown", async function (event) {
+            if (event.ctrlKey && event.shiftKey) {
+                const target = document.elementFromPoint(window._lastMousePosition.x, window._lastMousePosition.y);
+                // When we can't find the attribute on the clicked element, we
+                // look for it on the body element.
+                const node = target.closest("[data-filename]") || target.querySelector("body");
+                const filename = node.attributes["data-filename"].value;
+                if (filename) {
+                    fetch("$address", { method: "POST", body: filename });
+                } else {
+                    alert("We could not find template file. Do you have Revise running?");
+                }
+            }
+        })
+        </script>
+        $tags
+        """
+        response.body = codeunits(replace(String(response.body), tags => script))
+    end
+    return response
+end
+
+end

--- a/ext/HypertextTemplatesReviseExt.jl
+++ b/ext/HypertextTemplatesReviseExt.jl
@@ -1,6 +1,7 @@
 module HypertextTemplatesReviseExt
 
 import HypertextTemplates
+import InteractiveUtils
 import Revise
 
 function HypertextTemplates.is_stale_template(file::AbstractString, previous_mtime::Float64)
@@ -19,6 +20,14 @@ function HypertextTemplates.is_stale_template(file::AbstractString, previous_mti
     else
         # If the file doesn't exist, it's not stale.
         return false
+    end
+end
+
+function HypertextTemplates._data_filename_attr(file::String)
+    if HypertextTemplates._DATA_FILENAME_ATTR[]
+        return [Symbol("data-filename") => file]
+    else
+        return Pair{Symbol,String}[]
     end
 end
 

--- a/src/HypertextTemplates.jl
+++ b/src/HypertextTemplates.jl
@@ -16,7 +16,7 @@ end
 
 # Exports.
 
-export @template_str, @create_template_str, render
+export @template_str, @create_template_str, render, TemplateFileLookup
 
 # Includes.
 

--- a/src/nodes/abstract.jl
+++ b/src/nodes/abstract.jl
@@ -40,9 +40,10 @@ end
 struct BuilderContext
     io::Symbol
     slots::Symbol
+    file::String
 
-    function BuilderContext()
-        return new(Symbol("#io#"), Symbol("#slots#"))
+    function BuilderContext(file::AbstractString)
+        return new(Symbol("#io#"), Symbol("#slots#"), file)
     end
 end
 

--- a/src/nodes/element.jl
+++ b/src/nodes/element.jl
@@ -93,7 +93,11 @@ function expression(c::BuilderContext, e::Element)
         if e.name in VOID_ELEMENTS
             quote
                 print($(c.io), "<", $(e.name))
-                $(print_attributes)($(c.io); $(attrs...))
+                $(print_attributes)(
+                    $(c.io);
+                    $(_data_filename_attr)($(c.file))...,
+                    $(attrs...),
+                )
                 print($(c.io), "/>")
             end
         else
@@ -101,7 +105,11 @@ function expression(c::BuilderContext, e::Element)
             body = expression(c, e.body)
             quote
                 print($(c.io), "<", $(e.name))
-                $(print_attributes)($(c.io); $(attrs...))
+                $(print_attributes)(
+                    $(c.io);
+                    $(_data_filename_attr)($(c.file))...,
+                    $(attrs...),
+                )
                 print($(c.io), ">")
                 $(body)
                 print($(c.io), "</", $(e.name), ">")
@@ -127,6 +135,11 @@ function expression(c::BuilderContext, e::Element)
         :($(name)($(c.io), $(slots); $(attrs...)))
     end
 end
+
+# Used in `HypertextTemplatesReviseExt` to toggle the `data-filename` attribute
+# on and off during tests. Not a public API, do not rely on this.
+const _DATA_FILENAME_ATTR = Ref(true)
+_data_filename_attr(::Any) = (;)
 
 function print_attributes(io::IO; attrs...)
     for (k, v) in attrs

--- a/src/nodes/function.jl
+++ b/src/nodes/function.jl
@@ -338,7 +338,7 @@ end
 # of the template is used. Note that this functionality only works when Revise is
 # loaded within the session.
 function expression(c::TemplateFunction)::Expr
-    context = BuilderContext()
+    context = BuilderContext(c.file)
     body = expression(context, c.body)
     name = Symbol(c.name)
     expr = if c.html

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -7,6 +7,36 @@ function is_stale_template(file, mtime)
     return false
 end
 
+# Internal type used to dispatch to the correct handler generating function
+# based on whether `Revise` and `HTTP` are loaded. See the
+# `HypertextTemplatesHTTPReviseExt` module for the actual implementation of the
+# feature.
+struct TemplateFileLookupType end
+
+"""
+    TemplateFileLookup(handler)
+
+This is a developer tool that can be added to an `HTTP` handler stack to allow
+the user to open the template file in their default editor by holding down the
+`Ctrl` key and clicking on the rendered template. This is useful for debugging
+navigating the template files instead of having to manually search through a
+codebase for the template file that renders a given item within a page.
+
+```julia
+HTTP.serve(router |> TemplateFileLookup, host, port)
+```
+
+Always add the `TemplateFileLookup` handler after the other handlers, since it
+needs to inject a script into the response to listen for clicks on the rendered
+template.
+"""
+TemplateFileLookup(handler) = _template_file_lookup(TemplateFileLookupType(), handler)
+
+function _template_file_lookup(T, handler)
+    function (request)
+        return handler(request)
+    end
+end
 
 # Logging hacks to drop warnings about invalid HTML tags but also capture them to a tag set.
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,50 +1,11 @@
 using HypertextTemplates
 using Test
 using ReferenceTests
+using Revise
 
 module Templates
 
-using HypertextTemplates
-
-template"templates/basic/for.html"
-template"templates/basic/julia.html"
-template"templates/basic/show.html"
-template"templates/basic/match.html"
-template"templates/basic/slot.html"
-template"templates/basic/named-slot.html"
-template"templates/basic/complete.html"
-template"templates/basic/props.html"
-template"templates/basic/layout.html"
-template"templates/basic/layout-usage.html"
-template"templates/basic/special-symbols.html"
-
-module Complex
-
-using HypertextTemplates
-
-template"templates/complex/layouts/base-layout.html"
-template"templates/complex/layouts/sidebar.html"
-template"templates/complex/layouts/docs.html"
-
-template"templates/complex/pages/home.html"
-template"templates/complex/pages/app.html"
-template"templates/complex/pages/help.html"
-template"templates/complex/pages/tutorials.html"
-
-template"templates/complex/components/button.html"
-template"templates/complex/components/dropdown.html"
-template"templates/complex/components/tooltip.html"
-template"templates/complex/components/modal.html"
-
-end
-
-module Keywords
-
-using HypertextTemplates
-
-template"templates/keywords/keywords.html"
-
-end
+include("templates.jl")
 
 end
 
@@ -57,6 +18,8 @@ function render(f, args...; kws...)
 end
 
 @testset "HypertextTemplates" begin
+    HypertextTemplates._DATA_FILENAME_ATTR[] = false
+
     templates = joinpath(@__DIR__, "templates")
 
     @testset "basic" begin
@@ -194,5 +157,14 @@ end
         )
         @test_throws UndefKeywordError render(TK.var"typed-props";)
         @test_throws TypeError render(TK.var"typed-props"; props = "string")
+    end
+
+    @testset "data-filename" begin
+        HypertextTemplates._DATA_FILENAME_ATTR[] = true
+        html = render(Templates.Complex.app)
+        @test contains(html, "data-filename")
+        @test contains(html, "base-layout.html")
+        @test contains(html, "sidebar.html")
+        @test contains(html, "app.html")
     end
 end

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -1,0 +1,41 @@
+using HypertextTemplates
+
+template"templates/basic/for.html"
+template"templates/basic/julia.html"
+template"templates/basic/show.html"
+template"templates/basic/match.html"
+template"templates/basic/slot.html"
+template"templates/basic/named-slot.html"
+template"templates/basic/complete.html"
+template"templates/basic/props.html"
+template"templates/basic/layout.html"
+template"templates/basic/layout-usage.html"
+template"templates/basic/special-symbols.html"
+
+module Complex
+
+using HypertextTemplates
+
+template"templates/complex/layouts/base-layout.html"
+template"templates/complex/layouts/sidebar.html"
+template"templates/complex/layouts/docs.html"
+
+template"templates/complex/pages/home.html"
+template"templates/complex/pages/app.html"
+template"templates/complex/pages/help.html"
+template"templates/complex/pages/tutorials.html"
+
+template"templates/complex/components/button.html"
+template"templates/complex/components/dropdown.html"
+template"templates/complex/components/tooltip.html"
+template"templates/complex/components/modal.html"
+
+end
+
+module Keywords
+
+using HypertextTemplates
+
+template"templates/keywords/keywords.html"
+
+end


### PR DESCRIPTION
Inject event listener that waits for Control-Shift-hover on an element in the
DOM and then finds the closest ancestor with a `data-filename` attribute and
opens that file with the user's default editor.