### PR TITLE
Support exact line numbers in template "goto" feature

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -330,6 +330,36 @@ Note that this does add a small amount of overhead. For production builds of
 your code you should ensure that `Revise` is not part of your build. If you do
 this then all templates will be run without checking for updated file contents.
 
+## Template Lookup
+
+During development you'll likely need to find the source file and line number of
+particular parts of the rendered HTML. This is usually done by searching the
+codebase for matching tag or attribute names with an editor's search feature.
+This becomes tedious though, so `HypertextTemplates` provides a "template
+lookup" feature that allows you to jump to the source file and line number of
+any part of the rendered HTML by hovering over it in the browser and pressing
+`Ctrl+Shift`.
+
+To set this up you'll need to have `Revise` loaded in your session, as you
+should if you're in a development setting. Doing this will automatically
+annotate all rendered HTML with special `data-htloc` attributes that contain the
+source file and line number of the template that rendered that part of the HTML.
+Secondly, you'll need to add the `TemplateFileLookup` middleware to the `HTTP`
+server that is serving your rendered HTML.
+
+```julia
+using HypertextTemplates
+using HTTP
+
+HTTP.serve(router |> TemplateFileLookup, host, port)
+```
+
+Now just hover your mouse over any part of your browser and press `Ctrl+Shift`.
+This will open your editor at the correct file and line number. You'll need to
+have set the `"EDITOR"` environment variable to your editor command in your
+`ENV` in your `~/.julia/config/startup.jl` file for this to work. See the Julia
+manual for more details on setting environment variables.
+
 ## Public Interface
 
 ```@autodocs

--- a/ext/HypertextTemplatesReviseExt.jl
+++ b/ext/HypertextTemplatesReviseExt.jl
@@ -23,9 +23,10 @@ function HypertextTemplates.is_stale_template(file::AbstractString, previous_mti
     end
 end
 
-function HypertextTemplates._data_filename_attr(file::String)
+function HypertextTemplates._data_filename_attr(file::String, line::Int)
     if HypertextTemplates._DATA_FILENAME_ATTR[]
-        return [Symbol("data-filename") => file]
+        filekey = HypertextTemplates._register_filename_mapping!(file)
+        return [Symbol("data-htloc") => "$filekey:$line"]
     else
         return Pair{Symbol,String}[]
     end

--- a/src/HypertextTemplates.jl
+++ b/src/HypertextTemplates.jl
@@ -45,8 +45,26 @@ const RESERVED_ELEMENT_NAMES = Set([
     JULIA_TAG,
 ])
 
+const DATA_FILENAME_MAPPING = Dict{String,Int}()
+const DATA_FILENAME_MAPPING_REVERSE = Dict{Int,String}()
+
+function _register_filename_mapping!(file::String)
+    key = get!(DATA_FILENAME_MAPPING, file) do
+        return length(DATA_FILENAME_MAPPING) + 1
+    end
+    if haskey(DATA_FILENAME_MAPPING_REVERSE, key) &&
+       DATA_FILENAME_MAPPING_REVERSE[key] != file
+        error("filename key collision: $key")
+    else
+        DATA_FILENAME_MAPPING_REVERSE[key] = file
+    end
+    return key
+end
+
 function __init__()
     PackageExtensionCompat.@require_extensions
+    empty!(DATA_FILENAME_MAPPING)
+    empty!(DATA_FILENAME_MAPPING_REVERSE)
     return nothing
 end
 

--- a/src/nodes/abstract.jl
+++ b/src/nodes/abstract.jl
@@ -29,6 +29,13 @@ function transform(n::EzXML.Node)
     end
 end
 
+function nodeline(node::EzXML.Node)
+    node_ptr = node.ptr
+    @assert node_ptr != C_NULL
+    @assert unsafe_load(node_ptr).typ == EzXML.ELEMENT_NODE
+    return unsafe_load(convert(Ptr{EzXML._Element}, node_ptr)).line
+end
+
 # TODO: is this hack sufficient, or required?
 function cdata(n::EzXML.Node)
     buffer = IOBuffer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,12 +170,23 @@ end
         @test_throws TypeError render(TK.var"typed-props"; props = "string")
     end
 
-    @testset "data-filename" begin
+    @testset "data-htloc" begin
         HypertextTemplates._DATA_FILENAME_ATTR[] = true
         html = render(Templates.Complex.app)
-        @test contains(html, "data-filename")
-        @test contains(html, "base-layout.html")
-        @test contains(html, "sidebar.html")
-        @test contains(html, "app.html")
+        @test contains(html, "data-htloc")
+
+        # Since the filenames are encoded as an integer counter in the order
+        # they are encountered, we need to map them back to the original
+        # filename for the test to be easily readable.
+        mapping = Dict(
+            basename(file) => line for
+            (file, line) in HypertextTemplates.DATA_FILENAME_MAPPING
+        )
+        @test contains(html, "$(mapping["base-layout.html"]):8")
+        @test contains(html, "$(mapping["sidebar.html"]):2")
+        @test contains(html, "$(mapping["app.html"]):4")
+        @test contains(html, "$(mapping["button.html"]):2")
+        @test contains(html, "$(mapping["dropdown.html"]):2")
+        @test contains(html, "$(mapping["dropdown.html"]):3")
     end
 end


### PR DESCRIPTION
Also encode the file name as an integer counter rather than rendering the entire filename in each attribute to reduce the clutter in rendered HTML.