### PR TITLE
Correct file and line info in generated code

### DIFF
--- a/src/HypertextTemplates.jl
+++ b/src/HypertextTemplates.jl
@@ -18,6 +18,11 @@ end
 
 export @template_str, @custom_element, @create_template_str, render, TemplateFileLookup
 
+# Constants.
+
+# Used for replacing package-specific file/line information in macro-generated code.
+const SRC_DIR = @__DIR__
+
 # Includes.
 
 include("utilities.jl")

--- a/src/custom_element.jl
+++ b/src/custom_element.jl
@@ -25,7 +25,7 @@ macro custom_element(name)
                 attributes...,
             )
         end
-    end
+    end |> lln_replacer(file, line)
 end
 
 function custom_element(io::IO, name::String, slots::NamedTuple; attributes...)

--- a/src/nodes/abstract.jl
+++ b/src/nodes/abstract.jl
@@ -24,7 +24,7 @@ function transform(n::EzXML.Node)
                 return Element(n)
             end
         else
-            return Text(cdata(n))
+            return Text(cdata(n), 0)
         end
     end
 end
@@ -32,7 +32,7 @@ end
 function nodeline(node::EzXML.Node)
     node_ptr = node.ptr
     @assert node_ptr != C_NULL
-    @assert unsafe_load(node_ptr).typ == EzXML.ELEMENT_NODE
+    @assert unsafe_load(node_ptr).typ in (EzXML.ELEMENT_NODE, EzXML.TEXT_NODE)
     return unsafe_load(convert(Ptr{EzXML._Element}, node_ptr)).line
 end
 

--- a/src/nodes/element.jl
+++ b/src/nodes/element.jl
@@ -108,7 +108,7 @@ function expression(c::BuilderContext, e::Element)
                     $(attrs...),
                 )
                 print($(c.io), "/>")
-            end
+            end |> lln_replacer(c.file, e.line)
         else
             name = Symbol(e.name)
             body = expression(c, e.body)
@@ -122,7 +122,7 @@ function expression(c::BuilderContext, e::Element)
                 print($(c.io), ">")
                 $(body)
                 print($(c.io), "</", $(e.name), ">")
-            end
+            end |> lln_replacer(c.file, e.line)
         end
     else
         name = Symbol(e.name)
@@ -132,7 +132,7 @@ function expression(c::BuilderContext, e::Element)
                     $(body)
                     return nothing
                 end
-            end)
+            end) |> lln_replacer(c.file, e.line)
         end
         slots = Expr(
             :tuple,
@@ -141,7 +141,7 @@ function expression(c::BuilderContext, e::Element)
                 (builder(Symbol(k), expression(c, v)) for (k, v) in e.slots)...,
             ),
         )
-        :($(name)($(c.io), $(slots); $(attrs...)))
+        :($(name)($(c.io), $(slots); $(attrs...))) |> lln_replacer(c.file, e.line)
     end
 end
 

--- a/src/nodes/for.jl
+++ b/src/nodes/for.jl
@@ -5,13 +5,15 @@ struct For <: AbstractNode
     item::String
     index::Union{String,Nothing}
     body::Vector{AbstractNode}
+    line::Int
 
-    function For(iter, item, index, body)
+    function For(iter, item, index, body, line)
         return new(
             _restore_special_symbols(iter),
             _restore_special_symbols(item),
             _restore_special_symbols(index),
             body,
+            line,
         )
     end
 end
@@ -25,7 +27,7 @@ function For(n::EzXML.Node)
         iter = key_default(attrs, "iter")
         item = key_default(attrs, "item")
         index = key_default(attrs, "index")
-        return For(iter, item, index, transform(EzXML.nodes(n)))
+        return For(iter, item, index, transform(EzXML.nodes(n)), nodeline(n))
     else
         error("expected a '<for>' tag, found: $tag")
     end
@@ -46,5 +48,5 @@ function expression(c::BuilderContext, f::For)
         for $(item) in $(iter)
             $(body)
         end
-    end
+    end |> lln_replacer(c.file, f.line)
 end

--- a/src/nodes/julia.jl
+++ b/src/nodes/julia.jl
@@ -2,9 +2,10 @@ const JULIA_TAG = "julia"
 
 struct Julia <: AbstractNode
     value::String
+    line::Int
 
-    function Julia(value)
-        return new(_restore_special_symbols(value))
+    function Julia(value, line)
+        return new(_restore_special_symbols(value), line)
     end
 end
 
@@ -13,7 +14,7 @@ function Julia(n::EzXML.Node)
     if length(attrs) == 1
         (name, value), = attrs
         if name == "value"
-            return Julia(isempty(value) ? name : value)
+            return Julia(isempty(value) ? name : value, nodeline(n))
         else
             error("expected a 'value' attribute for a julia node.")
         end
@@ -26,7 +27,7 @@ function expression(c::BuilderContext, j::Julia)
     expr = Meta.parse(j.value)
     quote
         $(escape_html)($(c.io), $(expr))
-    end
+    end |> lln_replacer(c.file, j.line)
 end
 
 function escape_html(io::IO, value)

--- a/src/nodes/show.jl
+++ b/src/nodes/show.jl
@@ -4,9 +4,10 @@ struct Show <: AbstractNode
     when::String
     body::Vector{AbstractNode}
     fallback::Vector{AbstractNode}
+    line::Int
 
-    function Show(when, body, fallback)
-        return new(_restore_special_symbols(when), body, fallback)
+    function Show(when, body, fallback, line)
+        return new(_restore_special_symbols(when), body, fallback, line)
     end
 end
 
@@ -17,7 +18,7 @@ function Show(n::EzXML.Node)
         haskey(attrs, "when") || error("expected a 'when' attribute for a 'show' node.")
         when = key_default(attrs, "when")
         nodes, fallback = split_fallback(n)
-        return Show(when, transform(nodes), transform(EzXML.nodes(fallback)))
+        return Show(when, transform(nodes), transform(EzXML.nodes(fallback)), nodeline(n))
     else
         error("expected a '<show>' tag, found: $tag")
     end
@@ -36,5 +37,5 @@ function expression(c::BuilderContext, s::Show)
         else
             $(fallback)
         end
-    end
+    end |> lln_replacer(c.file, s.line)
 end

--- a/src/nodes/slot.jl
+++ b/src/nodes/slot.jl
@@ -3,21 +3,22 @@ const UNNAMED_SLOT = "#unnamed_slot#"
 
 struct Slot <: AbstractNode
     name::Union{String,Nothing}
+    line::Int
 
-    function Slot(name)
-        return new(_restore_special_symbols(name))
+    function Slot(name, line)
+        return new(_restore_special_symbols(name), line)
     end
 end
 
 function Slot(n::EzXML.Node)
     attrs = attributes(n)
     if isempty(attrs)
-        return Slot(nothing)
+        return Slot(nothing, nodeline(n))
     else
         if length(attrs) == 1
             (name, value), attrs... = attrs
             if isempty(value)
-                return Slot(name)
+                return Slot(name, nodeline(n))
             else
                 error("slot name attributes should be valueless, got: $value.")
             end
@@ -33,5 +34,5 @@ function expression(c::BuilderContext, s::Slot)
     else
         name = Symbol(s.name)
         :($(c.slots).$(name)($(c.io)))
-    end
+    end |> lln_replacer(c.file, s.line)
 end

--- a/src/nodes/text.jl
+++ b/src/nodes/text.jl
@@ -1,8 +1,9 @@
 struct Text <: AbstractNode
     content::String
+    line::Int
 
-    function Text(content::String)
-        return new(_restore_special_symbols(content))
+    function Text(content::String, line)
+        return new(_restore_special_symbols(content), line)
     end
 end
 
@@ -16,7 +17,7 @@ function Text(n::EzXML.Node)
         right = rstrip(content)
         content = right == content ? content : "$right "
 
-        return Text(all(isspace, content) ? "" : content)
+        return Text(all(isspace, content) ? "" : content, nodeline(n))
     else
         error("expected a text node, found: $(EzXML.nodename(n))")
     end
@@ -26,6 +27,6 @@ function expression(c::BuilderContext, t::Text)
     if isempty(t.content)
         return nothing
     else
-        :(print($(c.io), $(t.content)))
+        :(print($(c.io), $(t.content))) |> lln_replacer(c.file, t.line)
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -95,3 +95,24 @@ function split_fallback(n::EzXML.Node)
     end
     return nodes, fallback
 end
+
+function lln_replacer(file::Union{String,Symbol}, line::Integer)
+    file = Symbol(file)
+    function (ex::Expr)
+        if line > 0
+            MacroTools.postwalk(ex) do each
+                if isa(each, LineNumberNode)
+                    if startswith(string(each.file), SRC_DIR)
+                        return LineNumberNode(line, file)
+                    else
+                        return each
+                    end
+                else
+                    return each
+                end
+            end
+        else
+            return ex
+        end
+    end
+end

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -15,6 +15,7 @@ template"templates/basic/layout-usage.html"
 template"templates/basic/special-symbols.html"
 template"templates/basic/custom-elements.html"
 template"templates/basic/splat.html"
+template"templates/basic/file-and-line-info.html"
 
 module Complex
 

--- a/test/templates/basic/file-and-line-info.html
+++ b/test/templates/basic/file-and-line-info.html
@@ -1,0 +1,31 @@
+<function file-and-line-info-1>
+    <julia value="unknown" />
+</function>
+
+<function file-and-line-info-2>
+    <div>
+        <match value="unknown">
+            <case when="_">
+                <div>Value is unknown.</div>
+            </case>
+        </match>
+    </div>
+</function>
+
+<function file-and-line-info-3>
+    <div>
+        <file-and-line-info />
+    </div>
+</function>
+
+<function file-and-line-info-4>
+    <div>
+        <file-and-line-info-2 />
+    </div>
+</function>
+
+<function file-and-line-info-5>
+    <div>
+        <file-and-line-info-3 />
+    </div>
+</function>


### PR DESCRIPTION
Switch out macro-generated file and line info in template functions with the correct locations based on the parsed template code. Makes stacktraces to errors in template functions point to the correct lines in the right files instead of internal package code.