### PR TITLE
feat(tailwind): add @tailwind_source macro for CSS class discovery

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,8 +18,16 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: "1"
+      - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Generate Tailwind sidecar
+        run: julia --project=docs/Examples -e 'using Pkg; Pkg.instantiate(); using Examples'
+      - name: Build Tailwind CSS
+        working-directory: docs/Examples
+        run: |
+          bun install
+          bun run build:css
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Manifest.toml
 .vscode
 .DS_Store
 /docs/src/**/*.html
+*.ht-source.css

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added context system with `@context` and `@get_context` macros for passing data through component trees without prop drilling [#40]
+- Added `@tailwind_source` macro for Tailwind CSS class discovery from Julia components [#50]
 
 ## [v2.2.3] - 2025-06-25
 
@@ -148,3 +149,4 @@ Initial release.
 [#35]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/35
 [#37]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/37
 [#40]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/40
+[#50]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/50

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 build/
 site/
+src/examples/

--- a/docs/Examples/.gitignore
+++ b/docs/Examples/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+assets/dist/app.css
+*.ht-source.css
+bun.lock

--- a/docs/Examples/Project.toml
+++ b/docs/Examples/Project.toml
@@ -4,6 +4,7 @@ authors = ["MichaelHatherly <michaelhatherly@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 HypertextTemplates = "c7d46f9d-34c3-4420-bf57-257f25aec718"
 ReloadableMiddleware = "6b39ad65-d4e1-4a6a-9d75-56e3fde28494"
 

--- a/docs/Examples/assets/app.css
+++ b/docs/Examples/assets/app.css
@@ -1,0 +1,14 @@
+@import "tailwindcss";
+@import "./app.ht-source.css"; /* ht:managed */
+
+/* Enable class-based dark mode for Tailwind CSS v4 */
+@variant dark (&:where(.dark, .dark *));
+
+/* Keyframes for progress bar stripes animation */
+@keyframes stripes {
+    0% { background-position: 0 0; }
+    100% { background-position: 1rem 0; }
+}
+
+/* Hide elements with x-cloak until Alpine initializes */
+[x-cloak] { display: none !important; }

--- a/docs/Examples/package.json
+++ b/docs/Examples/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hypertexttemplates-examples",
+  "private": true,
+  "scripts": {
+    "build:css": "bunx @tailwindcss/cli -i ./assets/app.css -o ./assets/dist/app.css",
+    "watch:css": "bunx @tailwindcss/cli -i ./assets/app.css -o ./assets/dist/app.css --watch"
+  },
+  "devDependencies": {
+    "@tailwindcss/cli": "^4"
+  }
+}

--- a/docs/Examples/src/Examples.jl
+++ b/docs/Examples/src/Examples.jl
@@ -6,6 +6,9 @@ using HypertextTemplates
 using HypertextTemplates.Elements
 using HypertextTemplates.Library
 
+# Configure Tailwind to find Library component classes
+@tailwind_source "../assets/app.css"
+
 # Shared components
 include("shared/html_document.jl")
 

--- a/docs/Examples/src/Routes.jl
+++ b/docs/Examples/src/Routes.jl
@@ -2,6 +2,7 @@ module Routes
 
 using HypertextTemplates
 using ReloadableMiddleware.Router
+import HTTP
 
 import ..Templates
 
@@ -16,6 +17,12 @@ import ..Templates
     } begin
         @<component
     end
+end
+
+@GET "/assets/dist/app.css" function (req)
+    css_path = joinpath(@__DIR__, "..", "assets", "dist", "app.css")
+    content = read(css_path, String)
+    return HTTP.Response(200, ["Content-Type" => "text/css"], content)
 end
 
 end

--- a/docs/Examples/src/shared/html_document.jl
+++ b/docs/Examples/src/shared/html_document.jl
@@ -12,13 +12,17 @@ function get_example_names()
     end
 end
 
-@component function HTMLDocument(; title::String, current_page::String = "")
+@component function HTMLDocument(;
+    title::String,
+    current_page::String = "",
+    css_path::String = "/assets/dist/app.css",
+)
     @html {lang = "en"} begin
         @head begin
             @meta {charset = "UTF-8"}
             @meta {name = "viewport", content = "width=device-width, initial-scale=1.0"}
             @title $title
-            @script {src = "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"}
+            @link {rel = "stylesheet", href = css_path}
             @script {
                 defer = true,
                 src = "https://cdn.jsdelivr.net/npm/@alpinejs/anchor@3.x.x/dist/cdn.min.js",
@@ -27,25 +31,6 @@ end
                 defer = true,
                 src = "https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js",
             }
-            @style {type = "text/tailwindcss"} begin
-                @text HypertextTemplates.SafeString("""
-                /* Enable class-based dark mode for Tailwind CSS v4 */
-                @variant dark (&:where(.dark, .dark *));
-
-                /* Keyframes for progress bar stripes animation */
-                @keyframes stripes {
-                    0% {
-                        background-position: 0 0;
-                    }
-                    100% {
-                        background-position: 1rem 0;
-                    }
-                }
-
-                /* Hide elements with x-cloak until Alpine initializes */
-                [x-cloak] { display: none !important; }
-                """)
-            end
             # # Load dropdown.js globally for dropdown components
             # # This ensures Alpine.data('dropdown', ...) is available for all dropdowns
             # @script begin

--- a/docs/generate_examples.jl
+++ b/docs/generate_examples.jl
@@ -5,6 +5,16 @@ using Examples
 build_dir = joinpath(@__DIR__, "src", "examples")
 mkpath(build_dir)
 
+# Copy compiled CSS to build directory
+css_src = joinpath(@__DIR__, "Examples", "assets", "dist", "app.css")
+css_dst = joinpath(build_dir, "app.css")
+if isfile(css_src)
+    cp(css_src, css_dst; force = true)
+    println("Copied app.css to examples directory")
+else
+    @warn "Compiled CSS not found at $css_src - run `bun run build:css` first"
+end
+
 println("Generating component examples...")
 
 # Generate HTML for each example
@@ -14,6 +24,7 @@ for entry in Examples.Templates.get_example_names()
         @render io Examples.Templates.@HTMLDocument {
             title = entry.title,
             current_page = entry.output_file,
+            css_path = "./app.css",
         } begin
             @<entry.component
         end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,7 +44,7 @@ include("generate_examples.jl")
 makedocs(
     sitename = "HypertextTemplates",
     format = Documenter.HTML(),
-    modules = [HypertextTemplates],
+    modules = [HypertextTemplates, HypertextTemplates.Library],
     doctest = true,
     pages = [
         "Home" => "index.md",

--- a/docs/src/library-components.md
+++ b/docs/src/library-components.md
@@ -188,6 +188,26 @@ The library requires Tailwind CSS v4 with default configuration. Components use:
 - Container queries for responsive behavior
 - Modern CSS features like `backdrop-filter`
 
+### Class Discovery with `@tailwind_source`
+
+Tailwind scans source files to discover which CSS classes to include. Since Library
+components live in Julia's package depot, use `@tailwind_source` to register the path:
+
+```julia
+module MyApp
+using HypertextTemplates
+using HypertextTemplates.Library
+
+@tailwind_source "../assets/app.css"
+end
+```
+
+This creates a sidecar file (`app.ht-source.css`) containing the `@source` directive
+and adds an `@import` to your CSS file. The sidecar contains the absolute depot path,
+which updates automatically when HypertextTemplates is updated.
+
+Add `*.ht-source.css` to `.gitignore` to keep machine-specific paths out of version control.
+
 ## Best Practices
 
 ### Performance

--- a/src/HypertextTemplates.jl
+++ b/src/HypertextTemplates.jl
@@ -61,6 +61,7 @@ export @element
 export @esc_str
 export @get_context
 export @render
+export @tailwind_source
 export @text
 export SafeString
 export StreamingRender
@@ -87,6 +88,7 @@ include("render.jl")
 include("stream.jl")
 include("cmfile.jl")
 include("once.jl")
+include("tailwind-source-macro.jl")
 
 # Library submodule:
 include("Library/Library.jl")

--- a/src/tailwind-source-macro.jl
+++ b/src/tailwind-source-macro.jl
@@ -1,0 +1,213 @@
+# Tailwind CSS v4 source path integration.
+
+const TAILWIND_MANAGED_MARKER = "/* ht:managed */"
+
+"""
+    @tailwind_source "path/to/app.css"
+
+Update a Tailwind CSS file with a `@source` directive pointing to
+HypertextTemplates.Library source files.
+
+During precompilation, this macro:
+1. Locates the CSS file relative to the calling file
+2. Gets the current depot path to HypertextTemplates.Library
+3. Creates a sidecar CSS file with the `@source` directive
+4. Inserts/updates a managed `@import` in the main CSS
+
+When HypertextTemplates updates, the dependent package recompiles and
+the path is automatically updated.
+
+# Example
+
+```julia
+module MyApp
+using HypertextTemplates
+using HypertextTemplates.Library
+
+# Updates assets/app.css with Library source path
+@tailwind_source "../assets/app.css"
+end
+```
+
+Given `app.css`, the macro creates `app.ht-source.css` containing:
+
+```css
+@source "/path/to/.julia/packages/HypertextTemplates/.../src/Library/**/*.jl";
+```
+
+And inserts this line into `app.css` after `@import "tailwindcss";`:
+
+```css
+@import "./app.ht-source.css"; /* ht:managed */
+```
+
+# Gitignore
+
+Add `*.ht-source.css` to your `.gitignore` to keep absolute paths out of
+version control.
+
+# How it works
+
+Tailwind CSS v4 uses the `@source` directive to specify which files to scan for
+class names. Since HypertextTemplates.Library lives in Julia's depot path (which
+changes on package updates), this macro automatically keeps the path current.
+
+The `/* ht:managed */` comment marks the import line as auto-managed, allowing
+the macro to find and update it on subsequent runs.
+"""
+macro tailwind_source(css_path)
+    # Resolve path relative to calling file (like @cm_component does)
+    dir = isnothing(__source__.file) ? pwd() : dirname(String(__source__.file))
+    full_css_path = isabspath(css_path) ? css_path : joinpath(dir, css_path)
+
+    # Get Library source path at macro expansion time
+    library_path = _library_source_dir()
+
+    return esc(
+        quote
+            # Track CSS file as dependency (recompile if it changes)
+            $(Base).include_dependency($full_css_path)
+
+            # Update CSS during precompilation
+            $(HypertextTemplates)._update_tailwind_source!($full_css_path, $library_path)
+
+            nothing
+        end,
+    )
+end
+
+"""
+    _library_source_dir() -> String
+
+Get the path to the HypertextTemplates Library source directory.
+"""
+function _library_source_dir()
+    pkg_path = pathof(@__MODULE__)
+    if isnothing(pkg_path)
+        error("Cannot determine HypertextTemplates package path")
+    end
+    return joinpath(dirname(pkg_path), "Library")
+end
+
+"""
+    _sidecar_path(css_path) -> String
+
+Compute the sidecar CSS path for a given main CSS file.
+`app.css` → `app.ht-source.css`
+"""
+function _sidecar_path(css_path::String)
+    return replace(css_path, r"\.css$" => ".ht-source.css")
+end
+
+"""
+    _update_tailwind_source!(css_path, library_path) -> Bool
+
+Update a Tailwind CSS file with a `@source` directive for the Library.
+Creates a sidecar file with the `@source` directive and adds an `@import`
+to the main CSS file.
+Returns `true` if any file was modified, `false` otherwise.
+"""
+function _update_tailwind_source!(css_path::String, library_path::String)
+    # Check file exists
+    if !isfile(css_path)
+        @warn "Tailwind CSS file not found, skipping @tailwind_source update" path =
+            css_path
+        return false
+    end
+
+    modified = false
+
+    # 1. Write sidecar file with @source directive
+    sidecar_path = _sidecar_path(css_path)
+    escaped_path = _escape_css_path(library_path)
+    sidecar_content = """@source "$escaped_path/**/*.jl";\n"""
+
+    existing_sidecar = isfile(sidecar_path) ? read(sidecar_path, String) : ""
+    if sidecar_content != existing_sidecar
+        try
+            _atomic_write(sidecar_path, sidecar_content)
+            @info "Updated Tailwind sidecar file" path = sidecar_path
+            modified = true
+        catch e
+            @warn "Failed to write Tailwind sidecar file" path = sidecar_path exception = e
+            return false
+        end
+    end
+
+    # 2. Update main CSS with @import for sidecar
+    content = try
+        read(css_path, String)
+    catch e
+        @warn "Failed to read Tailwind CSS file" path = css_path exception = e
+        return false
+    end
+
+    sidecar_basename = basename(sidecar_path)
+    import_line = """@import "./$sidecar_basename"; $TAILWIND_MANAGED_MARKER"""
+
+    # Replace existing managed @import or insert new
+    managed_regex = r"@import\s+\"[^\"]+\"\s*;\s*/\*\s*ht:managed\s*\*/"
+    new_content = if occursin(managed_regex, content)
+        replace(content, managed_regex => import_line)
+    else
+        _insert_after_import(content, import_line)
+    end
+
+    if new_content != content
+        try
+            _atomic_write(css_path, new_content)
+            @info "Updated Tailwind CSS file" path = css_path
+            modified = true
+        catch e
+            @warn "Failed to update Tailwind CSS file" path = css_path exception = e
+            return false
+        end
+    end
+
+    return modified
+end
+
+"""
+    _escape_css_path(path) -> String
+
+Escape a file path for use in CSS. Uses forward slashes universally.
+"""
+function _escape_css_path(path::String)
+    # Use forward slashes universally (works in CSS on all platforms)
+    path = replace(path, "\\" => "/")
+    # Escape quotes
+    path = replace(path, "\"" => "\\\"")
+    return path
+end
+
+"""
+    _insert_after_import(content, line) -> String
+
+Insert a line after `@import "tailwindcss";` or at the top if not found.
+"""
+function _insert_after_import(content::String, line::String)
+    # Try to find @import "tailwindcss"; or @import 'tailwindcss';
+    import_regex = r"(@import\s+[\"']tailwindcss[\"']\s*;)"
+    if occursin(import_regex, content)
+        return replace(content, import_regex => SubstitutionString("\\1\n$line"))
+    end
+
+    # Fallback: insert at the beginning
+    return line * "\n" * content
+end
+
+"""
+    _atomic_write(path, content)
+
+Write content to a file atomically using a temp file and rename.
+"""
+function _atomic_write(path::String, content::String)
+    dir = dirname(path)
+    temp = joinpath(dir, ".ht_tailwind_tmp_$(getpid())_$(rand(UInt32))")
+    try
+        write(temp, content)
+        mv(temp, path; force = true)
+    finally
+        isfile(temp) && rm(temp; force = true)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,6 +262,9 @@ end
     # Include context tests
     include("context-tests.jl")
 
+    # Include tailwind source tests
+    include("tailwind-source-tests.jl")
+
     # Include Library tests
     include("Library/runtests.jl")
 end

--- a/test/tailwind-source-tests.jl
+++ b/test/tailwind-source-tests.jl
@@ -1,0 +1,178 @@
+@testset "Tailwind Source Macro" begin
+    # Test helper functions directly
+    @testset "Library path resolution" begin
+        lib_path = HypertextTemplates._library_source_dir()
+        @test isdir(lib_path)
+        @test isfile(joinpath(lib_path, "Library.jl"))
+    end
+
+    @testset "CSS path escaping" begin
+        # Forward slashes on all platforms
+        @test HypertextTemplates._escape_css_path("C:\\Users\\test") == "C:/Users/test"
+        # Quote escaping
+        @test HypertextTemplates._escape_css_path("path\"with\"quotes") ==
+              "path\\\"with\\\"quotes"
+        # Normal path unchanged
+        @test HypertextTemplates._escape_css_path("/normal/path") == "/normal/path"
+    end
+
+    @testset "Sidecar path computation" begin
+        @test HypertextTemplates._sidecar_path("/path/to/app.css") ==
+              "/path/to/app.ht-source.css"
+        @test HypertextTemplates._sidecar_path("styles.css") == "styles.ht-source.css"
+    end
+
+    @testset "Insert after import" begin
+        # With @import "tailwindcss"
+        content = """@import "tailwindcss";
+
+.custom { color: red; }
+"""
+        result = HypertextTemplates._insert_after_import(content, "@import \"test\";")
+        @test occursin("@import \"tailwindcss\";\n@import \"test\";", result)
+        @test occursin(".custom { color: red; }", result)
+
+        # With single quotes
+        content_single = """@import 'tailwindcss';
+body { margin: 0; }
+"""
+        result_single =
+            HypertextTemplates._insert_after_import(content_single, "@import \"test\";")
+        @test occursin("@import 'tailwindcss';\n@import \"test\";", result_single)
+
+        # No import - fallback to prepend
+        content_no_import = """.custom { color: red; }
+"""
+        result_no_import =
+            HypertextTemplates._insert_after_import(content_no_import, "@import \"test\";")
+        @test startswith(result_no_import, "@import \"test\";")
+    end
+
+    # Test the main update function with temp files
+    mktempdir() do tmpdir
+        @testset "Creates sidecar and inserts @import" begin
+            css_path = joinpath(tmpdir, "test1.css")
+            sidecar_path = joinpath(tmpdir, "test1.ht-source.css")
+            write(
+                css_path,
+                """@import "tailwindcss";
+
+.custom { color: red; }
+""",
+            )
+
+            lib_path = HypertextTemplates._library_source_dir()
+            result = @test_logs (:info, r"sidecar") (:info, r"CSS file") begin
+                HypertextTemplates._update_tailwind_source!(css_path, lib_path)
+            end
+
+            @test result == true
+
+            # Sidecar file created with @source directive
+            @test isfile(sidecar_path)
+            sidecar_content = read(sidecar_path, String)
+            @test occursin("@source", sidecar_content)
+            # Path is escaped (backslashes → forward slashes on Windows)
+            escaped_lib_path = HypertextTemplates._escape_css_path(lib_path)
+            @test occursin(escaped_lib_path, sidecar_content)
+
+            # Main CSS has @import with ht:managed marker
+            content = read(css_path, String)
+            @test occursin("ht:managed", content)
+            @test occursin("@import \"./test1.ht-source.css\"", content)
+            @test occursin(r"@import.*tailwindcss.*\n@import.*ht-source", content)
+        end
+
+        @testset "Update existing managed @import" begin
+            css_path = joinpath(tmpdir, "test2.css")
+            sidecar_path = joinpath(tmpdir, "test2.ht-source.css")
+            write(
+                css_path,
+                """@import "tailwindcss";
+@import "./old-sidecar.css"; /* ht:managed */
+
+.custom { color: red; }
+""",
+            )
+
+            lib_path = HypertextTemplates._library_source_dir()
+            result = @test_logs (:info, r"sidecar") (:info, r"CSS file") begin
+                HypertextTemplates._update_tailwind_source!(css_path, lib_path)
+            end
+
+            @test result == true
+            content = read(css_path, String)
+            @test !occursin("old-sidecar", content)
+            @test occursin("test2.ht-source.css", content)
+            # Should only have one managed line
+            @test count("ht:managed", content) == 1
+
+            # Sidecar should exist
+            @test isfile(sidecar_path)
+        end
+
+        @testset "Idempotent update" begin
+            lib_path = HypertextTemplates._library_source_dir()
+            escaped_path = HypertextTemplates._escape_css_path(lib_path)
+            css_path = joinpath(tmpdir, "test3.css")
+            sidecar_path = joinpath(tmpdir, "test3.ht-source.css")
+
+            # Pre-create both files in expected state
+            write(sidecar_path, """@source "$escaped_path/**/*.jl";\n""")
+            write(
+                css_path,
+                """@import "tailwindcss";
+@import "./test3.ht-source.css"; /* ht:managed */
+""",
+            )
+
+            result = HypertextTemplates._update_tailwind_source!(css_path, lib_path)
+            @test result == false  # No change needed
+        end
+
+        @testset "Missing file warning" begin
+            nonexistent = joinpath(tmpdir, "nonexistent.css")
+            @test_logs (:warn, r"not found") begin
+                result =
+                    HypertextTemplates._update_tailwind_source!(nonexistent, "/some/path")
+                @test result == false
+            end
+        end
+
+        @testset "Fallback insertion at top" begin
+            css_path = joinpath(tmpdir, "test5.css")
+            sidecar_path = joinpath(tmpdir, "test5.ht-source.css")
+            write(
+                css_path,
+                """.custom { color: red; }
+""",
+            )
+
+            lib_path = HypertextTemplates._library_source_dir()
+            result = @test_logs (:info, r"sidecar") (:info, r"CSS file") begin
+                HypertextTemplates._update_tailwind_source!(css_path, lib_path)
+            end
+
+            @test result == true
+
+            # Main CSS has @import at top
+            content = read(css_path, String)
+            @test startswith(content, "@import")
+            @test occursin("ht:managed", content)
+
+            # Sidecar created
+            @test isfile(sidecar_path)
+        end
+
+        @testset "Atomic write" begin
+            css_path = joinpath(tmpdir, "test_atomic.css")
+            content = "@import \"tailwindcss\";\n"
+            HypertextTemplates._atomic_write(css_path, content)
+
+            @test isfile(css_path)
+            @test read(css_path, String) == content
+            # No temp files left behind
+            @test isempty(filter(f -> startswith(f, ".ht_tailwind_tmp"), readdir(tmpdir)))
+        end
+    end
+end


### PR DESCRIPTION
Adds `@tailwind_source` macro for Tailwind CSS class discovery from Julia components.

## How it works

The macro writes the Library `@source` path to a gitignored sidecar file (`*.ht-source.css`) and adds an `@import` to the main CSS file. This keeps absolute depot paths out of version control.

```julia
@tailwind_source "../assets/app.css"
```

Given `app.css`, creates:
- `app.ht-source.css` (gitignored): contains `@source "/path/to/Library/**/*.jl";`
- Updates `app.css` with: `@import "./app.ht-source.css"; /* ht:managed */`

Add `*.ht-source.css` to `.gitignore`.