### PR TITLE
refactor(deps): move CodeTracking to Revise extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refine Library component design system: slate neutrals, indigo accents, precise shadows, faster transitions [#51]
+- Move `CodeTracking` from direct dependency to Revise extension via `Revise.CodeTracking` [#58]
 
 ## [v2.2.3] - 2025-06-25
 
@@ -155,3 +156,4 @@ Initial release.
 [#40]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/40
 [#50]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/50
 [#51]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/51
+[#58]: https://github.com/MichaelHatherly/HypertextTemplates.jl/issues/58

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Michael Hatherly <michaelhatherly@gmail.com>"]
 version = "2.2.3"
 
 [deps]
-CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
@@ -24,7 +23,6 @@ HypertextTemplatesHTTPExt = "HTTP"
 HypertextTemplatesReviseExt = "Revise"
 
 [compat]
-CodeTracking = "1.3, 2, 3"
 InteractiveUtils = "1.6"
 MacroTools = "0.5"
 PackageExtensionCompat = "1"

--- a/ext/HypertextTemplatesReviseExt.jl
+++ b/ext/HypertextTemplatesReviseExt.jl
@@ -5,4 +5,39 @@ import Revise
 
 HTT.__is_revise_loaded(::HTT.ReviseIsLoaded) = true
 
+function _has_uuid(vec::Vector{Base.CodeInfo}, uuid::Symbol)
+    for each in vec
+        if uuid in each.slotnames
+            return true
+        end
+    end
+    return false
+end
+
+function HTT._method_offset(::HTT.ReviseIsLoaded, f, uuid, __source__)
+    if !isdefined(Revise, :CodeTracking)
+        @debug "CodeTracking not available via Revise, skipping source tracking."
+        return nothing
+    end
+    method = nothing
+    for candidate in methods(f)
+        lowered = Base.code_lowered(f, Base.tuple_type_tail(candidate.sig))
+        if _has_uuid(lowered, uuid)
+            method = candidate
+            break
+        end
+    end
+    if isnothing(method)
+        @debug "could not detect method, giving up."
+        return nothing
+    else
+        try
+            return Revise.CodeTracking.whereis(__source__, method)
+        catch err
+            @debug "CodeTracking.whereis failed, skipping source tracking." exception = err
+            return nothing
+        end
+    end
+end
+
 end

--- a/src/HypertextTemplates.jl
+++ b/src/HypertextTemplates.jl
@@ -44,7 +44,6 @@ module HypertextTemplates
 
 # Imports:
 
-import CodeTracking
 import PackageExtensionCompat
 import MacroTools
 

--- a/src/render-macro.jl
+++ b/src/render-macro.jl
@@ -82,46 +82,19 @@ function _source_info(__source__)
     euuid = esc(uuid)
     quuid = QuoteNode(Symbol(lstrip(String(uuid), '#')))
     return quote
-        if $(HypertextTemplates)._is_revise_loaded()
-            let $(euuid) =
-                    $(esc(Expr(:isdefined, self))) ? $(esc(Symbol("#self#"))) : nothing
-                $(HypertextTemplates)._method_offset(
-                    $(euuid),
-                    $(quuid),
-                    $(QuoteNode(__source__)),
-                )
-            end
-        else
-            nothing
+        let $(euuid) =
+                $(esc(Expr(:isdefined, self))) ? $(esc(Symbol("#self#"))) : nothing
+            $(HypertextTemplates)._method_offset(
+                $(HypertextTemplates).ReviseIsLoaded(),
+                $(euuid),
+                $(quuid),
+                $(QuoteNode(__source__)),
+            )
         end
     end
 end
 
-function _has_uuid(vec::Vector{Base.CodeInfo}, uuid::Symbol)
-    for each in vec
-        if uuid in each.slotnames
-            return true
-        end
-    end
-    return false
-end
-
-function _method_offset(f, uuid, __source__)
-    method = nothing
-    for candidate in methods(f)
-        lowered = Base.code_lowered(f, Base.tuple_type_tail(candidate.sig))
-        if _has_uuid(lowered, uuid)
-            method = candidate
-            break
-        end
-    end
-    if isnothing(method)
-        @debug "could not detect method, giving up."
-        return nothing
-    else
-        return CodeTracking.whereis(__source__, method)
-    end
-end
+_method_offset(::Any, f, uuid, __source__) = nothing
 
 function _render(dst, dom_thunk::Function, source::Tuple{String,Integer})
     io = _render_dst(dst)


### PR DESCRIPTION
Access `CodeTracking` via `Revise.CodeTracking` instead of carrying it as a direct dependency. Moves `_method_offset` and `_has_uuid` into the Revise extension, with a no-op fallback in the main module. Simplifies `_source_info` to always dispatch through `ReviseIsLoaded()`.